### PR TITLE
Use # to add 0x prefix to hex format specifier

### DIFF
--- a/common/stdio.c
+++ b/common/stdio.c
@@ -97,9 +97,19 @@ int vsnprintf(char* buffer, size_t size, const char* format, va_list args) {
         case 'd':
         case 'i':
         case 'u':
-        case 'x': {
+        case 'x':
+        case '#': {
             char num_buf[20];
-            itoa(va_arg(args, int), num_buf, ch == 'x' ? 16 : 10);
+            if (*format == 'x') {
+                buffer[idx++] = '0';
+                buffer[idx++] = 'x';
+                if (idx >= size)
+                    goto too_long;
+
+                itoa(va_arg(args, int), num_buf, *format++ == 'x' ? 16 : 10);
+            } else {
+                itoa(va_arg(args, int), num_buf, ch == 'x' ? 16 : 10);
+            }
 
             size_t len = strlen(num_buf);
             if (pad_len > len) {


### PR DESCRIPTION
Hi!

Normally to add a `0x` prefix there's a `#` specifier which can be added before printing a hexadecimal value. So when needed, instead of adding a `0x` prefix, user can use `#` which will append a `0x` prefix at first. E.g. `printf("%#x");` instead of `printf("0x%x");`

Although what I added isn't the most correct implementation at all, but a bare minimum. When specifying a hexadecimal value with a certain length, e.g. `%#04x`, this approach *will not work*, as `4` will be interpreted as an integer rather than the length.

I think, the easiest way would be to just append zero's with the length of the hex value. For example, `%#04x` where the whole value (including the prefix `0x`) will be equal to 4 characters in length and without prefix will be 2 characters in length. 

Best regards.