### PR TITLE
Warn user when they exceed maximum int value in sleep and others

### DIFF
--- a/common/escp.h
+++ b/common/escp.h
@@ -19,6 +19,8 @@
 #define F_YELLOW        "\x1b[33m"
 #define F_BLUE          "\x1b[34m"
 #define F_MAGENTA       "\x1b[35m"
+#define F_CYAN          "\x1b[36m"
+#define F_WHITE         "\x1b[37m"
 
 #define B_DEFAULT_COLOR "\x1b[49m"
 #define B_BLACK         "\x1b[40m"
@@ -27,3 +29,5 @@
 #define B_YELLOW        "\x1b[43m"
 #define B_BLUE          "\x1b[44m"
 #define B_MAGENTA       "\x1b[45m"
+#define B_CYAN          "\x1b[46m"
+#define B_WHITE         "\x1b[47m"

--- a/common/limits.h
+++ b/common/limits.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#define CHAR_BIT        8
+
+#define SCHAR_MIN       0x7f
+#define SCHAR_MAX       -(0x7f + 1)
+
+#ifdef __CHAR_UNSIGNED__
+    #define CHAR_MIN    0
+    #define CHAR_MAX    0xff
+#else
+    #define CHAR_MIN    SCHAR_MIN
+    #define CHAR_MAX    SCHAR_MAX
+#endif
+
+#define SHRT_MIN        -(0x7fff + 1)
+#define SHRT_MAX        0x7fff
+#define USHRT_MIN       0
+#define USHRT_MAX       0xffff
+
+#define INT_MIN         -(0x7fffffff + 1)
+#define INT_MAX         0x7fffffff
+
+#ifdef __LP64__
+    #define ULONG_MAX	0xffffffffffffffffUL
+    #define LONG_MAX	0x7fffffffffffffffL
+    #define LONG_MIN	-(0x7fffffffffffffffL - 1)
+#else
+    #define ULONG_MAX	0xffffffffUL
+    # define LONG_MAX	0x7fffffffL
+    #define LONG_MIN	-(0x7fffffffL - 1)
+#endif
+
+#define ULLONG_MAX      0xffffffffffffffffULL
+#define LLONG_MIN	    -(0x7fffffffffffffffLL - 1)
+#define LLONG_MAX	    0x7fffffffffffffffLL

--- a/userland/sleep.c
+++ b/userland/sleep.c
@@ -47,7 +47,7 @@ int main(int argc, char* const argv[]) {
     }
 
     int val = atoi(argv[1]);
-    if (val < INT_MIN) {
+    if (val < 0) { /* We'd expect if user pass less than zero, but only passing zero is accepted */
         dprintf(STDERR_FILENO, "Input time is lower than minimum interger length\n");
         return EXIT_FAILURE;
     }

--- a/userland/sleep.c
+++ b/userland/sleep.c
@@ -38,13 +38,25 @@
 #include <time.h>
 #include <unistd.h>
 #include <escp.h>
+#include <limits.h>
 
 int main(int argc, char* const argv[]) {
     if (argc != 2) {
         dprintf(STDERR_FILENO, "%susage: %ssleep %s<%stime-in-seconds%s>%s\n", F_MAGENTA, F_GREEN, F_BLUE, F_GREEN, F_BLUE, RESET);
         return EXIT_FAILURE;
     }
-    struct timespec req = {.tv_sec = atoi(argv[1]), .tv_nsec = 0};
+
+    int val = atoi(argv[1]);
+    if (val < INT_MIN) {
+        dprintf(STDERR_FILENO, "Input time is lower than minimum interger length\n");
+        return EXIT_FAILURE;
+    }
+    if (val > INT_MAX) {
+        dprintf(STDERR_FILENO, "Input time is higher than maximum interger length\n");
+        return EXIT_FAILURE;
+    }
+
+    struct timespec req = {.tv_sec = val, .tv_nsec = 0};
     if (nanosleep(&req, NULL) < 0) {
         perror("nanosleep");
         return EXIT_FAILURE;


### PR DESCRIPTION
Hello,

When using `sleep` a user can exceed `INT_MAX` which results in a negative value being passed.  `nanosleep` doesn't seem like do anything for this and ignores it. Warning the user that they've exceeded `INT_MAX` by showing a message about it would be a nice idea. And normally, `INT_MAX`  is defined in `limits.h` so I've also added a very minimal `limits.h` (for example, it doesn't check specific compiler or if linking against a specific C version, but I believe it's not required for now).

Also, in `escp.h` there should be two more colors, aqua and white. So I've added that as well.

More information is in the [commit](https://github.com/Dashbloxx/magma/commit/62bcf5ca1b251e8c0d7842ad982161b86b67ec7e) message.

Thanks!